### PR TITLE
Render parent properties

### DIFF
--- a/libs/builder/builder.js
+++ b/libs/builder/builder.js
@@ -422,6 +422,7 @@ Vvveb.Components = {
 			if (property.beforeInit) property.beforeInit(element.get(0)) 
 			
 			if (property.child) element = element.find(property.child);
+			if (property.parent) element = element.parent(property.parent);
 			
 			if (property.data) {
 				property.data["key"] = property.key;


### PR DESCRIPTION
If you select an element, the values of the parent properties are not populated correctly